### PR TITLE
Missed URLs for tabs navigation

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -64,6 +64,7 @@ class App extends Component {
                     image={ item.image }
                     title={ item.title }
                     description={ item.description }
+                    url={ item.url }
                   />
                 ))
               }
@@ -79,6 +80,7 @@ class App extends Component {
                     image={ item.image }
                     title={ item.title }
                     description={ item.description }
+                    url={ item.url }
                   />
                 ))
               }
@@ -94,6 +96,7 @@ class App extends Component {
                     image={ item.image }
                     title={ item.title }
                     description={ item.description }
+                    url={ item.url }
                   />
                 ))
               }


### PR DESCRIPTION
Looks like `url` attribute is missing on certain tabs, so when user tries to filter podcasts with tabs, they are not clickable anymore.